### PR TITLE
Handle cases when issue body is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ Toolkit.run(async (tools) => {
     ...tools.context.issue,
   });
 
-  bodyList.push(issue.body);
+  if (issue.body) {
+    bodyList.push(issue.body)
+  };
 
   const { data: comments } = await tools.github.issues.listComments({
     ...tools.context.issue,

--- a/index.test.js
+++ b/index.test.js
@@ -110,6 +110,32 @@ describe("Require Checklist", () => {
       "The following items are not marked as completed: Two, Three"
     );
   });
+
+  it("handles issues with empty body, requireChecklist disabled", async () => {
+    process.env.INPUT_REQUIRECHECKLIST = "false";
+
+    mockIssueBody(null);
+    mockIssueComments(["No checklist in comment"]);
+
+    tools.exit.success = jest.fn();
+    await action(tools);
+    expect(tools.exit.success).toBeCalledWith(
+      "There are no incomplete task list items"
+    );
+  });
+
+  it("handles issues with empty body, requireChecklist enabled", async () => {
+    process.env.INPUT_REQUIRECHECKLIST = "true";
+
+    mockIssueBody(null);
+    mockIssueComments(["No checklist in comment"]);
+
+    tools.exit.failure = jest.fn();
+    await action(tools);
+    expect(tools.exit.failure).toBeCalledWith(
+      "No task list was present and requireChecklist is turned on"
+    );
+  });
 });
 
 function mockIssueBody(body) {


### PR DESCRIPTION
This action is currently failing if the body of the PR is empty. 

```
Run mheap/require-checklist-action@v1
  with:
    requireChecklist: false
  env:
    GITHUB_TOKEN: ***
Error: Cannot read property 'matchAll' of null
✖  fatal     TypeError: Cannot read property 'matchAll' of null 
    at /home/runner/work/_actions/mheap/require-checklist-action/v1/dist/index.js:32:28
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```