### PR TITLE
Add issue number input

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ jobs:
       - uses: mheap/require-checklist-action@v2
         with:
           requireChecklist: false # If this is true and there are no checklists detected, the action will fail
+          issueNumber: 1234 # The pull request number, used for when this action is triggered from another workflow
 ```
 
 ### Inapplicable checklist items

--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ A GitHub Action that fails a pull request if there are any incomplete checklists
 
 ## Usage
 
-Create a file named `.github/workflows/require-checklist.yaml` (or any name in that directory) with the following content:
+Create a file named `.github/workflows/require-checklist.yaml` (or any name in that directory), this file will contain the body of your GitHub Action.
+
+### Use with a `pull_request` or `issue` event
+
+This action will default to using the `pull_request` or `issue` number when used inside a workflow triggered by one of those events. Below is an example of how to use it.
 
 ```yaml
 name: Require Checklist
+
 on:
   pull_request:
     types: [opened, edited, synchronize]
   issues:
     types: [opened, edited, deleted]
+
 jobs:
   job1:
     runs-on: ubuntu-latest
@@ -20,7 +26,29 @@ jobs:
       - uses: mheap/require-checklist-action@v2
         with:
           requireChecklist: false # If this is true and there are no checklists detected, the action will fail
-          issueNumber: 1234 # The pull request number, used for when this action is triggered from another workflow
+```
+
+### Use with a `workflow_run` event
+
+If you would like to use this action outside of a `pull_request` or `issue` trigger. You can pass in the issue number manually. Note that "issue number" is used even in the context of pull requests.
+
+```yaml
+name: Require Checklist
+
+on:
+  workflow_run:
+    workflows: ["Other Workflow"]
+    types:
+      - completed
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/require-checklist-action@v2
+        with:
+          requireChecklist: false # If this is true and there are no checklists detected, the action will fail
+          issueNumber: ${{ github.event.workflow_run.pull_requests[0].number }}
 ```
 
 ### Inapplicable checklist items

--- a/index.js
+++ b/index.js
@@ -9,9 +9,19 @@ async function action() {
   const token = core.getInput("token");
   const octokit = github.getOctokit(token);
 
+  const issueNumber =
+    github.context.issue?.number ?? core.getInput("issueNumber");
+
+  core.debug(`issue number: ${issueNumber}`);
+
+  if (!issueNumber) {
+    core.setFailed("Could not determine issue number");
+    return;
+  }
+
   const { data: issue } = await octokit.rest.issues.get({
     ...github.context.repo,
-    issue_number: github.context.issue.number,
+    issue_number: issueNumber,
   });
 
   if (issue.body) {
@@ -20,7 +30,7 @@ async function action() {
 
   const { data: comments } = await octokit.rest.issues.listComments({
     ...github.context.repo,
-    issue_number: github.context.issue.number,
+    issue_number: issueNumber,
   });
 
   for (let comment of comments) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ async function action() {
   const octokit = github.getOctokit(token);
 
   const issueNumber =
-    github.context.issue?.number ?? core.getInput("issueNumber");
+    core.getInput("issueNumber") || github.context.issue?.number;
 
   core.debug(`issue number: ${issueNumber}`);
 

--- a/index.test.js
+++ b/index.test.js
@@ -222,6 +222,28 @@ describe("Require Checklist", () => {
 
     expect(core.setFailed).toBeCalledWith("Could not determine issue number");
   });
+
+  it("defaults to using the input issue number on pull_request event", async () => {
+    process.env.INPUT_ISSUENUMBER = 11;
+
+    mockIssueBody("Nothing in the body", process.env.INPUT_ISSUENUMBER);
+    mockIssueComments(
+      ["Demo\r\n\r\n- [x] One\r\n- [ ] Two\n- [ ] Three"],
+      process.env.INPUT_ISSUENUMBER
+    );
+
+    console.log = jest.fn();
+    core.setFailed = jest.fn();
+    await action(tools);
+
+    expect(console.log).toBeCalledWith("Completed task list item: One");
+    expect(console.log).toBeCalledWith("Incomplete task list item: Two");
+    expect(console.log).toBeCalledWith("Incomplete task list item: Three");
+
+    expect(core.setFailed).toBeCalledWith(
+      "The following items are not marked as completed: Two, Three"
+    );
+  });
 });
 
 function mockIssueBody(body, issueNumber = 17) {

--- a/index.test.js
+++ b/index.test.js
@@ -108,7 +108,6 @@ describe("Require Checklist", () => {
     mockIssueComments(["Demo\r\n\r\n- [x] One\r\n- [ ] Two\n- [ ] Three"]);
 
     console.log = jest.fn();
-    console.log = jest.fn();
     core.setFailed = jest.fn();
     await action(tools);
 
@@ -155,23 +154,87 @@ describe("Require Checklist", () => {
 
     core.setFailed = jest.fn();
     await action(tools);
+
     expect(core.setFailed).toBeCalledWith(
       "No task list was present and requireChecklist is turned on"
     );
   });
+
+  it("handles using issue number input with completed checklist", async () => {
+    process.env.INPUT_REQUIRECHECKLIST = "true";
+    process.env.INPUT_ISSUENUMBER = 11;
+
+    const runTools = mockEvent("workflow_run", {});
+
+    mockIssueBody(
+      "Demo\r\n\r\n- [x] One\r\n- [x] Two\n- [x] Three",
+      process.env.INPUT_ISSUENUMBER
+    );
+    mockIssueComments(["- [x] Comment done"], process.env.INPUT_ISSUENUMBER);
+
+    console.log = jest.fn();
+    await action(runTools);
+
+    expect(console.log).toBeCalledWith("Completed task list item: One");
+    expect(console.log).toBeCalledWith("Completed task list item: Two");
+    expect(console.log).toBeCalledWith("Completed task list item: Three");
+    expect(console.log).toBeCalledWith(
+      "Completed task list item: Comment done"
+    );
+
+    expect(console.log).toBeCalledWith(
+      "There are no incomplete task list items"
+    );
+  });
+
+  it("handles using issue number input with incomplete checklist in comments", async () => {
+    process.env.INPUT_ISSUENUMBER = 11;
+
+    const runTools = mockEvent("workflow_run", {});
+
+    mockIssueBody("Nothing in the body", process.env.INPUT_ISSUENUMBER);
+    mockIssueComments(
+      ["Demo\r\n\r\n- [x] One\r\n- [ ] Two\n- [ ] Three"],
+      process.env.INPUT_ISSUENUMBER
+    );
+
+    console.log = jest.fn();
+    core.setFailed = jest.fn();
+    await action(runTools);
+
+    expect(console.log).toBeCalledWith("Completed task list item: One");
+    expect(console.log).toBeCalledWith("Incomplete task list item: Two");
+    expect(console.log).toBeCalledWith("Incomplete task list item: Three");
+
+    expect(core.setFailed).toBeCalledWith(
+      "The following items are not marked as completed: Two, Three"
+    );
+  });
+
+  it("handles missing issue number", async () => {
+    process.env.INPUT_REQUIRECHECKLIST = "true";
+    delete process.env.INPUT_ISSUENUMBER;
+
+    const runTools = mockEvent("workflow_run", {});
+
+    core.setFailed = jest.fn();
+    await action(runTools);
+
+    expect(core.setFailed).toBeCalledWith("Could not determine issue number");
+  });
 });
 
-function mockIssueBody(body) {
+function mockIssueBody(body, issueNumber = 17) {
   nock("https://api.github.com")
-    .get("/repos/YOUR_USERNAME/action-test/issues/17")
+    .get(`/repos/YOUR_USERNAME/action-test/issues/${issueNumber}`)
     .reply(200, {
       body,
     });
 }
 
-function mockIssueComments(comments) {
+function mockIssueComments(comments, issueNumber = 17) {
   nock("https://api.github.com")
-    .get("/repos/YOUR_USERNAME/action-test/issues/17/comments")
+    .get(`/repos/YOUR_USERNAME/action-test/issues/${issueNumber}/comments`)
     .reply(
       200,
       comments.map((c) => {

--- a/index.test.js
+++ b/index.test.js
@@ -212,7 +212,6 @@ describe("Require Checklist", () => {
   });
 
   it("handles missing issue number", async () => {
-    process.env.INPUT_REQUIRECHECKLIST = "true";
     delete process.env.INPUT_ISSUENUMBER;
 
     const runTools = mockEvent("workflow_run", {});


### PR DESCRIPTION
This PR adds a new input parameter to `requires-checklist-action`, allowing consumers to pass in the issue/pull request number they're interested in scanning for checklists.

**Intended use:**

```yml
name: Checklist Check

on:
  workflow_run:
    workflows: ["Other Workflow"]
    types:
      - completed

jobs:
  checklist_job:
    runs-on: ubuntu-latest
    name: Check checklist job
    steps:
      - name: Require Checklist
        uses: mheap/require-checklist-action@v2
        with:
          requireChecklist: false
          issueNumber: ${{ github.event.workflow_run.pull_requests[0].number }}

```