### PR TITLE
Add support for skipping when description matches a regex pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ jobs:
           issueNumber: ${{ github.event.workflow_run.pull_requests[0].number }}
 ```
 
+### Optional checkboxes
+
+Optional checkboxes can be applied with the `skipDescriptionRegex` argument, which supports any regex statement supported by [Javascript's RegExp class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp).
+
+```yaml
+name: Require Checklist
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+  issues:
+    types: [opened, edited, deleted]
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/require-checklist-action@v2
+        with:
+          skipDescriptionRegex: ^\(Optional\)
+```
+
 ### Inapplicable checklist items
 
 In case there are some items that are not applicable in given checklist they can be ~stroked through~ and this action will ignore them. For example:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ jobs:
 
 ### Optional checkboxes
 
-Optional checkboxes can be applied with the `skipDescriptionRegex` argument, which supports any regex statement supported by [Javascript's RegExp class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp).
+Optional checkboxes can be applied with the `skipDescriptionRegex` and `skipDescriptionRegexFlags` arguments, which correspond to the first and second constructor arguments of [Javascript's RegExp class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp).
+
+Here is an example of skipping any description with including "(Optional)". (case-insensitive).
 
 ```yaml
 name: Require Checklist
@@ -70,7 +72,8 @@ jobs:
     steps:
       - uses: mheap/require-checklist-action@v2
         with:
-          skipDescriptionRegex: ^\(Optional\)
+          skipDescriptionRegex: .*\(optional\).*
+          skipDescriptionRegexFlags: i
 ```
 
 ### Inapplicable checklist items

--- a/README.md
+++ b/README.md
@@ -58,13 +58,7 @@ Optional checkboxes can be applied with the `skipDescriptionRegex` and `skipDesc
 Here is an example of skipping any description with including "(Optional)". (case-insensitive).
 
 ```yaml
-name: Require Checklist
-
-on:
-  pull_request:
-    types: [opened, edited, synchronize]
-  issues:
-    types: [opened, edited, deleted]
+# ...
 
 jobs:
   job1:

--- a/action.yml
+++ b/action.yml
@@ -19,3 +19,7 @@ inputs:
     description: Do not look for checklists in comments
     required: false
     default: "false"
+  skipDescriptionRegex:
+    description: A regex pattern of descriptions that will be skipped if matched
+    required: false
+    default: undefined

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ async function action() {
   const token = core.getInput("token");
   const octokit = github.getOctokit(token);
   const skipRegexPattern = core.getInput("skipDescriptionRegex");
-  const skipDescriptionRegex = !!skipRegexPattern ? new RegExp(skipRegexPattern) : false;
+  const skipRegexFlags = core.getInput("skipDescriptionRegexFlags");
+  const skipDescriptionRegex = !!skipRegexPattern ? new RegExp(skipRegexPattern, skipRegexFlags) : false;
 
   const issueNumber =
     core.getInput("issueNumber") || github.context.issue?.number;

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ async function action() {
 
   const token = core.getInput("token");
   const octokit = github.getOctokit(token);
+  const skipRegexPattern = core.getInput("skipDescriptionRegex");
+  const skipDescriptionRegex = !!skipRegexPattern ? new RegExp(skipRegexPattern) : false;
 
   const issueNumber =
     core.getInput("issueNumber") || github.context.issue?.number;
@@ -60,6 +62,11 @@ async function action() {
         var matches = [...line.matchAll(TASK_LIST_ITEM)];
         for (let item of matches) {
           var is_complete = item[1] != " ";
+
+          if(skipRegexPattern && skipDescriptionRegex.test(item[2])) {
+            console.log("Skipping task list item: " + item[2]);
+            continue;
+          }
 
           containsChecklist = true;
 

--- a/index.test.js
+++ b/index.test.js
@@ -289,11 +289,12 @@ describe("Require Checklist", () => {
     );
   });
 
-  it("ignores items that match the skipDescriptionRegex pattern", async () => {
+  it("ignores items that match the skipDescriptionRegex + skipDescriptionRegexFlags args", async () => {
     process.env.INPUT_REQUIRECHECKLIST = "true";
-    process.env.INPUT_SKIPDESCRIPTIONREGEX = "\(Optional\)";
+    process.env.INPUT_SKIPDESCRIPTIONREGEX = ".*\(optional\).*";
+    process.env.INPUT_SKIPDESCRIPTIONREGEXFLAGS = "i";
 
-    mockIssueBody("Demo\r\n\r\n- [x] One\r\n- [x] Two\n- [x] (Optional) This is skipped");
+    mockIssueBody("Demo\r\n\r\n- [x] One\r\n- [x] Two\n- [x] This is (Optional) skipped");
 
     console.log = jest.fn();
 
@@ -301,11 +302,14 @@ describe("Require Checklist", () => {
 
     expect(console.log).toBeCalledWith("Completed task list item: One");
     expect(console.log).toBeCalledWith("Completed task list item: Two");
-    expect(console.log).toBeCalledWith("Skipping task list item: (Optional) This is skipped");
+    expect(console.log).toBeCalledWith("Skipping task list item: This is (Optional) skipped");
 
     expect(console.log).toBeCalledWith(
       "There are no incomplete task list items"
     );
+
+    delete process.env.INPUT_SKIPDESCRIPTIONREGEX;
+    delete process.env.INPUT_SKIPDESCRIPTIONREGEXFLAGS;
   });
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -288,6 +288,25 @@ describe("Require Checklist", () => {
       "There are no incomplete task list items"
     );
   });
+
+  it("ignores items that match the skipDescriptionRegex pattern", async () => {
+    process.env.INPUT_REQUIRECHECKLIST = "true";
+    process.env.INPUT_SKIPDESCRIPTIONREGEX = "\(Optional\)";
+
+    mockIssueBody("Demo\r\n\r\n- [x] One\r\n- [x] Two\n- [x] (Optional) This is skipped");
+
+    console.log = jest.fn();
+
+    await action(tools);
+
+    expect(console.log).toBeCalledWith("Completed task list item: One");
+    expect(console.log).toBeCalledWith("Completed task list item: Two");
+    expect(console.log).toBeCalledWith("Skipping task list item: (Optional) This is skipped");
+
+    expect(console.log).toBeCalledWith(
+      "There are no incomplete task list items"
+    );
+  });
 });
 
 function mockIssueBody(body, issueNumber = 17) {


### PR DESCRIPTION
I'm working on a project that uses some checkboxes (with a predicable description pattern) to orchestrate some CI actions. To prevent confusion, I don't want those checkboxes to be required by this require-checklist action, so I added some parameters, `skipDescriptionRegex` and `skipDescriptionRegexPattern` to allow configurable skipping of checkboxes.